### PR TITLE
skip transloadit for no-op form submission

### DIFF
--- a/js/lib/jquery.transloadit2.js
+++ b/js/lib/jquery.transloadit2.js
@@ -56,6 +56,10 @@
       : r;
   };
 
+  function validFileFields() {
+    return this.$form.find('input[type=file]').not(this._options.exclude);
+  }
+
   function Uploader() {
     this.assemblyId = null;
 
@@ -90,9 +94,9 @@
 
     var self = this;
     $form.bind('submit.transloadit', function() {
-      if (self._options.beforeStart()) {
-        self.getBoredInstance();
-      }
+      // If there are no valid upload fields, transloadit() is a no-op
+      if (validFileFields.call(self).length == 0) return true;
+      if (self._options.beforeStart()) self.getBoredInstance();
       return false;
     });
 
@@ -168,9 +172,7 @@
       return;
     }
 
-    this.$files = this.$form
-      .find('input[type=file]')
-      .not(this._options.exclude);
+    this.$files = validFileFields.call(this);
 
     self.$fileClones = $().not(document);
     this.$files.each(function() {


### PR DESCRIPTION
I've incorporated the beforeStart callback from anderssvendal but added another case. If your "exclude" option to the plugin results in no file fields being matched, the transloadit() submit handler becomes a no-op and just passes through to the default action of the form.

The main case for this is for when you want to pass in `{exclude: function() { return !$(this).val(); }}` which would have the effect of not transloading if a form's upload fields are empty. 
