### PR TITLE
added configurable retry limit on json data errors

### DIFF
--- a/js/lib/jquery.transloadit2.js
+++ b/js/lib/jquery.transloadit2.js
@@ -241,7 +241,7 @@
         self.assembly = assembly;
         if (assembly.error == 'ASSEMBLY_NOT_FOUND') {
           self.pollRetries++;
-          if (self.pollRetries > 15) {
+          if (self.pollRetries > self._options.retry_limit) {
             document.title = self.documentTitle;
             self.ended = true;
             self.renderError(assembly);


### PR DESCRIPTION
I was getting a number of users reporting JSONP timeout errors. So I've added an option for retry_limit which in my testing (set at 100) seems to eliminate these problems, and users are able to upload larger files without hitting the limit. I should say that in my testing I set the interval to 10000 as well so that it polls for progress less often. 

I haven't changed the defaults in the code, just added the option for retry_limit.

Cheers
