### PR TITLE
'include' param: jQuery selector for b64 encoded file data contained in arbitrary form elements

### DIFF
--- a/js/lib/jquery.transloadit2.js
+++ b/js/lib/jquery.transloadit2.js
@@ -26,6 +26,7 @@
       , wait: false
       , autoSubmit: true
       , modal: true
+	  , include: ''
       , exclude: ''
       , fields: false
       , debug: true
@@ -172,9 +173,19 @@
       return;
     }
 
-    this.$files = this.$form
-      .find('input[type=file]')
-      .not(this._options.exclude);
+	// EDIT PATCH FOR PHONEGAP
+	// Add 'include : string' to params to add files in classed inputs
+	// Note: will automatically add include to params.exclude to omit from fields
+	if(this.params.include){
+		this.$files = this.$form
+	      .find(this._options.include)
+	      .not(this._options.exclude);
+	}else{
+	    this.$files = this.$form
+	      .find('input[type=file]')
+	      .not(this._options.exclude);
+	}
+
 
     self.$fileClones = $().not(document);
     this.$files.each(function() {
@@ -204,6 +215,7 @@
 
     this.$form
       .find(':input[type!=file]')
+	  .not(this._options.include)
       .filter(fieldsFilter)
       .clone()
       .prependTo(this.$uploadForm);


### PR DESCRIPTION
Added 'include' to params to enable b64 encoded images in arbitrary DOM elements to be uploaded. This negates the input:type=file read-only problem in frameworks such as PhoneGap where access to camera data is as b64 or file uri only. 

Note: this reintroduces the classic security flaw and could be used to send arbitrary data to a server. However most mobile applicaitons operate in a sandbox and have no access to any data other than within it's own namespace. Therefore this risk is mitigated.
