### PR TITLE
Include Param

### DIFF
--- a/js/lib/jquery.transloadit2.js
+++ b/js/lib/jquery.transloadit2.js
@@ -172,9 +172,19 @@
       return;
     }
 
-    this.$files = this.$form
-      .find('input[type=file]')
-      .not(this._options.exclude);
+	// EDIT PATCH FOR PHONEGAP
+	// Add 'include : string' to params to add files in classed inputs
+	// Note: will automatically add include to params.exclude to omit from fields
+	if(this.params.include){
+		this.$files = this.$form
+	      .find(this._options.include)
+	      .not(this._options.exclude);
+	}else{
+	    this.$files = this.$form
+	      .find('input[type=file]')
+	      .not(this._options.exclude);
+	}
+
 
     self.$fileClones = $().not(document);
     this.$files.each(function() {
@@ -204,6 +214,7 @@
 
     this.$form
       .find(':input[type!=file]')
+	  .not(this._options.include)
       .filter(fieldsFilter)
       .clone()
       .prependTo(this.$uploadForm);


### PR DESCRIPTION
Added 'include' to params list which adds files for upload based on a valid jQuery selector.

Note that this adds a considerable security problem for desktop browsers but is necessary for frameworks such as PhoneGap where files are retrieved in JS at strings, in these environments we're running in a sandbox so problem is mitigated by OS security.
