### PR TITLE
Tweak plugin to work for our needs

### DIFF
--- a/js/lib/jquery.transloadit2.js
+++ b/js/lib/jquery.transloadit2.js
@@ -115,7 +115,7 @@
     this.options($.extend({}, OPTIONS, options || {}));
 
     var self = this;
-    $form.bind('submit.transloadit', function() {
+    $form.on('change', 'input[type="file"]', function() {
       self.validate();
       self.detectFileInputs();
       self.checkFileTypes();
@@ -127,16 +127,6 @@
       }
 
       return false;
-    });
-
-    if (this._options['triggerUploadOnFileSelection']) {
-      $form.on('change', 'input[type="file"]', function() {
-        $form.trigger('submit.transloadit');
-      });
-    }
-
-    $form.on('change', 'input[type="file"]', function() {
-      self._options.onFileSelect($(this).val(), $(this));
     });
 
     this.includeCss();


### PR DESCRIPTION
Hey,

I have modified the jquery sdk plugin to cater for our needs. Can I explain to you my needs and see if I am doing the right thing?
- Upload needs to start as soon as a file has been picked
- Form must not be submitted until user has clicked Submit (Can't be submitted while uploads are in progress)

I know my needs sound pretty basic but I could not get the plugin to work in its current condition. Was I doing something wrong?

See below for our current config.

```
      wait: false
      modal: false
      autoSubmit: false
      processZeroFiles: true
      triggerUploadOnFileSelection: true
      params: @params
      signature: @signature
```

Cheers,
Daniel
