### PR TITLE
Fix `formData` Upload

### DIFF
--- a/js/lib/jquery.transloadit2.js
+++ b/js/lib/jquery.transloadit2.js
@@ -284,14 +284,16 @@
       .appendTo('body')
       .hide();
 
+    var url = PROTOCOL+this.instance+'/assemblies/'+this.assemblyId+'?redirect=false';
+
     if (this._options.formData) {
       this._options.formData.append("params", this.$form.find("input[name=params]").val());
       var f = new XMLHttpRequest();
-      f.open("POST", b);
+      f.open("POST", url);
       f.send(this._options.formData);
     } else {
       this.$uploadForm = $('<form enctype="multipart/form-data" />')
-        .attr('action', PROTOCOL+this.instance+'/assemblies/'+this.assemblyId+'?redirect=false')
+        .attr('action', url)
         .attr('target', 'transloadit-' + this.assemblyId)
         .attr('method', 'POST')
         .append(this.$files)


### PR DESCRIPTION
We're trying to upload our Transloadit library to the latest over at Sprint.ly and we kept getting the following error:

![screen shot 2014-02-14 at 6 12 41 pm](https://f.cloud.github.com/assets/126919/2176921/15862938-95e7-11e3-91ce-0e834c2cce53.png)

And I checked line 290 where it checks for a `formData` option and posts via `XMLHttpRequest` and it was referencing a var, `b`, that was not set anywhere in-scope. I've pulled out the URL used for the `<form>` post method, and put it into a variable for both methods to reference and it seems to work now.

Please take a look at my changes and let me know if there's anything I'm missing/misunderstanding. And I don't see any unit tests in this repo, but I'm happy to write one if you've got an existing suite somewhere that I can add on to.

Thanks!
