### PR TITLE
Don't show error modal when options.debug = false

### DIFF
--- a/js/lib/jquery.transloadit2.js
+++ b/js/lib/jquery.transloadit2.js
@@ -678,6 +678,10 @@
       return;
     }
 
+    if (!this._options.debug) {
+      return this.cancel();
+    }
+
     this.$modal.$content.addClass('content-error');
     this.$modal.$progress.hide();
     this.$modal.$label.hide();


### PR DESCRIPTION
[The documentation](https://transloadit.com/docs#jquery-plugin) says that setting `debug` to `false` will prevent error modals, but the current version of the library does not seem to respect that.

I think this is the appropriate code change. Please advise if not.
