### PR TITLE
Fixes _modal.renderCancelling when modal is false

### DIFF
--- a/js/lib/jquery.transloadit.js
+++ b/js/lib/jquery.transloadit.js
@@ -568,7 +568,9 @@ const tus = require('tus-js-client')
         this._$params.prependTo(this._$form)
       }
 
-      this._modal.renderCancelling()
+      if (this._options.modal) {
+        this._modal.renderCancelling()
+      }
 
       if (this._assembly) {
         this._assembly.cancel(hideModal)


### PR DESCRIPTION
Fixes a bug where _modal.renderCancelling is still invoked when an upload is cancelled but the `modal` parameter is set to `false`.  Since `modal` is undefined when set to false, an error was thrown.