### PR TITLE
Clear the _internetConnectionChecker’s Interval when calling destroy().

### DIFF
--- a/js/lib/jquery.transloadit.js
+++ b/js/lib/jquery.transloadit.js
@@ -553,6 +553,7 @@ const tus = require('tus-js-client')
       this.stop()
       this.reset()
       this.unbindEvents()
+      clearInterval(this._internetConnectionChecker._interval)
       this._$form.data('transloadit.uploader', null)
     }
 


### PR DESCRIPTION
On single page apps, these intervals can build up over time if they are not cleared when the form is destroyed. This can results in tons of overlapping, never-ending requests to check if we're still online.