### PR TITLE
Enable retries for tus uploads

### DIFF
--- a/js/lib/jquery.transloadit.js
+++ b/js/lib/jquery.transloadit.js
@@ -367,6 +367,7 @@ const tus = require('tus-js-client')
           filename    : file.name,
           assembly_url: assemblyUrl,
         },
+        retryDelays: [0, 1000, 3000, 5000],
         fingerprint (file) {
           // Fingerprinting is not necessary any more since we have disabled
           // the resuming of previous uploads.


### PR DESCRIPTION
This tells tus-js-client to retry requests if possible (e.g. after server error or network failure). It uses the same delays as Uppy does: https://github.com/transloadit/uppy/blob/6839a4c0d74ad161cdaecca750fcf5f71ef188d0/packages/%40uppy/tus/src/index.js#L73