### PR TITLE
Fix note rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This is a **jQuery** SDK to make it easy to talk to the [Transloadit](https://tr
 
 ## Install
 
-<div class="tip" markdown="1">
-  You may also be interested in checking out [Uppy](https://transloadit.com/docs/sdks/uppy/), Transloadit's next-gen file uploader for the web.
+<div class="alert alert-note">
+  <strong>Note:</strong> You may also be interested in checking out <a href="https://transloadit.com/docs/sdks/uppy/">Uppy</a>, Transloadit's next-gen file uploader for the web.
 </div>
 
 Simply include the JavaScript asset in your HTML page like so. jQuery >= 1.9 is also required.


### PR DESCRIPTION
Before:

<img width="846" alt="image" src="https://user-images.githubusercontent.com/375537/165298614-bac130e4-15c2-45a7-9104-3835942a9fc3.png">

After:

<img width="818" alt="image" src="https://user-images.githubusercontent.com/375537/165298684-8d2573a8-5671-40a7-b83a-1d4552588af5.png">

* * *

On the website:

<img width="846" alt="image" src="https://user-images.githubusercontent.com/375537/165298765-ed39a2bc-aa32-4623-aba9-cbeb1ce2f151.png">

 ↓

<img width="858" alt="image" src="https://user-images.githubusercontent.com/375537/165298889-a5795264-5806-40d0-98c4-8741ac5f0cb0.png">
 
